### PR TITLE
[main] Update to newest charts build scripts

### DIFF
--- a/scripts/pull-scripts
+++ b/scripts/pull-scripts
@@ -1,12 +1,15 @@
-#!/usr/bin/env bash
-set -e
+#!/bin/bash
+set -e # Exit immediately if a command exits with a non-zero status.
 
-cd $(dirname $0)
+cd $(dirname $0) # Move to the directory of the script
+source ./version # Source the version file to set environment variables
 
-source ./version
-
+# Check if the charts-build-scripts binary exists in the ../bin directory
 if ls ../bin/charts-build-scripts 1>/dev/null 2>/dev/null; then
-    CURRENT_SCRIPT_VERSION="v$(../bin/charts-build-scripts --version | cut -d' ' -f3)"
+    # Use awk to split the version output correctly and extract the version number
+    CURRENT_SCRIPT_VERSION="v$(../bin/charts-build-scripts --version | awk '{print $3}')"
+    echo "Current version: ${CURRENT_SCRIPT_VERSION}, Expected version: ${CHARTS_BUILD_SCRIPT_VERSION}"
+    # Exit if the current version matches the expected version
     if [[ "${CURRENT_SCRIPT_VERSION}" == "${CHARTS_BUILD_SCRIPT_VERSION}" ]]; then
         exit 0
     fi
@@ -14,34 +17,42 @@ fi
 
 echo "Downloading charts-build-scripts version ${CHARTS_BUILD_SCRIPTS_REPO}@${CHARTS_BUILD_SCRIPT_VERSION}"
 
+# Remove existing ../bin directory and change to the parent dir.
 rm -rf ../bin
 cd ..
 
-mkdir -p bin
+mkdir -p bin # Re-create bin dir
+
+# Extract the OS and architecture from the go version command output
 OS=$(go version | cut -d' ' -f4 | cut -d'/' -f1)
 ARCH=$(go version | cut -d' ' -f4 | cut -d'/' -f2)
 
+# Determine the binary name based on the OS and architecture
 if [[ "$OS" == "windows" ]]; then
     BINARY_NAME="charts-build-scripts_${OS}_${ARCH}.exe"
 else
     BINARY_NAME="charts-build-scripts_${OS}_${ARCH}"
 fi
-response_code=$(curl -s -o bin/charts-build-scripts -w "%{http_code}" -L "${CHARTS_BUILD_SCRIPTS_REPO%.git}/releases/download/${CHARTS_BUILD_SCRIPT_VERSION}/${BINARY_NAME}")
 
-# Fall back to binary name format from old release scheme
-if ! [[ -f bin/charts-build-scripts ]] || [[ "$response_code" == "404" ]]; then
+# Download the binary from the charts-build-scripts repository
+curl -s -L ${CHARTS_BUILD_SCRIPTS_REPO%.git}/releases/download/${CHARTS_BUILD_SCRIPT_VERSION}/${BINARY_NAME} --output bin/charts-build-scripts
+
+# If the binary is not found or contains "Not Found", Fall back to binary name format from old release scheme
+if ! [[ -f bin/charts-build-scripts ]] || [[ $(cat bin/charts-build-scripts) == "Not Found" ]]; then
     echo "Falling back to old binary name format..."
-    rm bin/charts-build-scripts; 
+    rm bin/charts-build-scripts; # Remove the not found old binary
+    # Determine the fallback binary name.
     if [[ ${OS} == "linux" ]]; then
         BINARY_NAME=charts-build-scripts
     else
         BINARY_NAME=charts-build-scripts-${OS}
     fi
-    response_code=$(curl -s -o bin/charts-build-scripts -w "%{http_code}" -L "${CHARTS_BUILD_SCRIPTS_REPO%.git}/releases/download/${CHARTS_BUILD_SCRIPT_VERSION}/${BINARY_NAME}")
+    # Attempt to download the binary using the fallback name.
+    curl -s -L ${CHARTS_BUILD_SCRIPTS_REPO%.git}/releases/download/${CHARTS_BUILD_SCRIPT_VERSION}/${BINARY_NAME} --output bin/charts-build-scripts
 fi
 
 # If falling back to old binary name format did not work, fail
-if ! [[ -f bin/charts-build-scripts ]] || [[ "$response_code" == "404" ]]; then
+if ! [[ -f bin/charts-build-scripts ]] || [[ $(cat bin/charts-build-scripts) == "Not Found" ]]; then
     echo "Failed to find charts-build-scripts binary"
     rm bin/charts-build-scripts;
     exit 1

--- a/scripts/version
+++ b/scripts/version
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 CHARTS_BUILD_SCRIPTS_REPO=https://github.com/rancher/charts-build-scripts.git
-CHARTS_BUILD_SCRIPT_VERSION=v0.9.2
+CHARTS_BUILD_SCRIPT_VERSION="${CHARTS_BUILD_SCRIPT_VERSION:-v1.3.2}"
 
 BUILD_TARGET=${BUILD_TARGET:-"prometheus-federator"}
 


### PR DESCRIPTION
Syncs `pull-scripts` from `rancher-charts` repo.
Also updates default build scripts to use same as `rancher-charts`.