### PR TITLE
docs: Add new details covering SemVer usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,36 @@
 # ob-team-charts
 A repo for Rancher Observability &amp; Backups team's charts - a canonical dev spot just before rancher/charts.
 
+## What O&B projects use this repo?
+
+This covers the following O&B team charts:
+- `rancher-monitoring`,
+- `rancher-project-monitoring`,
+- `prometheus-federator`, and
+- `rancher-logging`
+
+This is where we apply the majority of the Rancher specific changes to these charts.
+None of the changes we apply at this level should be specific to a single Rancher minor version.
+
+## How do we manage Chart version numbers?
+
+The short version, most charts should use this syntax: `{upstream version}-rancher.{incrementing number}`.
+
+Where each new `{upstream version}` resets the `{incrementing number}`. The result being that for any upstream version 
+that we release, we will also be able to track what rancher specific changes were applied.
+And that this version is universal across all Rancher minor versions that support a given `{upstream version}`.
+
+For more specifics on why this format is used, see: [How do we manage Chart versions across this repo and `rancher/charts`?](./docs/semver-across-chart-repos.md)
+
 ## How does rebasing for Rancher Monitoring charts work with this repo?
-Today this repo is primarily used to benefit `rancher-monitoring`, `rancher-project-monitoring` and `prometheus-federator`.
-Specifically to incorporate the following benefits:
+Overall the process isn't too different, however how we manage a particular upstream version will be different.
+In the new system, we will suffix each upstream version with a `-rancher.{num}` identifier.
+
+Using that will give us a better identifier for our Rancher specific modifications that we use across Rancher minor versions.
+Specifically some other ways this will benfit our team is:
 - O&B team maintains a single canonical version of upstream chart changes,
-- `rancher-monitoring` and `rancher-project-monitoirng` rebase can be a single PR.
+- `rancher-monitoring` and `rancher-project-monitoirng` rebase can be a single PR
+  - Then followed up by PRs in `rancher/prometheus-federator` and all synced to `rancher/charts` in unison. 
 
 Please review the [Monitoring Rebase doc](./docs/monitoring-rebase.md) for more details on the process this repo allows.
+

--- a/docs/semver-across-chart-repos.md
+++ b/docs/semver-across-chart-repos.md
@@ -1,0 +1,28 @@
+# How do we manage Chart versions across this repo and `rancher/charts`?
+
+Essentially, we must respect SemVer and understand how it interacts both:
+a) within `ob-team-charts` and b) on the `rancher/charts` repo.
+
+So first, the best ELI5, primer of SemVer for a refresher:
+- A SemVer consists of: `core version`, `build metadata` (optional), `prerelease identifier` (optional),
+- When SemVer encounters a `-<some details>` **first** it will consider the version a pre-release.
+- When SemVer encounters a `+<some details>` **first** everything following `+` will be considered build metadata (even `-` characters).
+- The `-` is considered part of `non-digit` characters to SemVer; it is valid within `<build>`
+- The `+` is not valid anywhere other than when separating and identifying where `<build>` starts
+- In other words, there are 3 forms of "extended SemVer" and they are:
+    - `<semver core>-<prerelease>`
+    - `<semver core>+<build>`
+    - `<semver core>-<prerelease>+<build>`
+
+With all that in mind, because we are adding a suffix in `ob-team-charts` we are using `-`.
+Which means that when testing charts directly from `ob-team-charts` the "Pre-release Charts" feature has to be enabled.
+(This is a per Rancher User setting if you test with multiple users, update all of them.)
+
+This way, once we are ready to ship an update to `rancher/charts` the final version will look like:
+`106.0.0+up{upstream}-rancher.{num}` - which is a valid SemVer with an optional `<build>` suffix.
+
+In contrast, consider if we used `+` then when we suffix the full `ob-team-charts` version at `rancher/charts` it would produce
+a version of `106.0.0+up{upstream}+rancher.{num}` which is invalid SemVer. In this scenario, we would have to adjust tooling
+used for `rancher/charts` to modify `+` in the upstream version to be a legal character.
+
+This led to our conclusion that we should continue using `-`


### PR DESCRIPTION
A follow up to:

https://github.com/rancher/ob-team-charts/pull/41
https://github.com/rancher/ob-team-charts/pull/42

To outline the lifecycle of charts and their versions as they go from this repo to `rancher/charts`.