### PR TITLE
repo: Add basic GH issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-chart-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01-chart-bug.yml
@@ -1,0 +1,79 @@
+name: Chart Bug 🐛
+description: Report a bug with one of our Helm charts
+title: "[<chart-slug> <version>] <title>"
+labels: [bug]
+assignees: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### 🧾 Suggested Title Format:
+        ```
+        [<chart-slug>][<version>] <short description>
+        ```
+        Example:
+        ```
+        [rancher-monitoring][61.3] Update Curl version to 8.12+
+        ```
+        If there are multiple versions affected you can skip the version tag.
+  - type: markdown
+    attributes:
+      value: |
+        ### 🧠 Title Guidelines
+        Try to follow [Conventional Commits](https://www.conventionalcommits.org/) for the `<title>` part when possible.
+
+        Example formats:
+        - `fix: unexpected pod restarts in Grafana`
+        - `feat: support custom scrape configs`
+        - `chore: bump image version for Prometheus`
+
+        This helps keep changelogs clean and meaningful!
+
+  - type: input
+    id: chart_slug
+    attributes:
+      label: Chart Slug
+      description: The slug of the chart (used in title), e.g. rancher-monitoring
+      placeholder: rancher-monitoring
+    validations:
+      required: true
+
+  - type: input
+    id: chart_versions
+    attributes:
+      label: Affected Chart Versions
+      description: Version where the bug occurs
+      placeholder: "61.3, or multiple versions"
+    validations:
+      required: true
+
+  - type: textarea
+    id: bug_details
+    attributes:
+      label: Bug Details
+      description: Describe the issue, steps to reproduce, logs, and any configuration involved.
+      placeholder: |
+        Steps to reproduce:
+        1. ...
+        
+        Logs:
+        ```log
+        ...
+        ```
+
+        Helm values (if any):
+        ```yaml
+        ...
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected Behavior
+      description: What should have happened instead?
+      placeholder: Describe the expected result
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/02-qa-testing.yml
+++ b/.github/ISSUE_TEMPLATE/02-qa-testing.yml
@@ -1,0 +1,78 @@
+name: Chart QA Request 🧪
+description: Request QA to test chart changes in a PR before merge
+title: "[QA][ob-team-charts] <chart-slug> <chart-version>"
+labels: [qa-request]
+assignees: []
+
+body:
+  - type: input
+    id: pull_request
+    attributes:
+      label: Pull Request
+      description: Link to the PR being with a chart needing to be tested
+      placeholder: e.g. https://github.com/org/repo/pr/1234
+    validations:
+      required: true
+  - type: input
+    id: root_issue
+    attributes:
+      label: Root Issue
+      description: Link to the main issue being addressed (this QA task blocks it)
+      placeholder: e.g. https://github.com/org/repo/issues/1234
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: |
+        ✅ After QA finishes testing:
+        - QA will close this issue as normal.
+        - Engineer merges the PR and updates the **root issue**.
+        - When the change is included in the release branch (RC), QA will test the full release using the **root issue**.
+
+        🔗 Keep traceability: Always link this issue to the main one it supports. (Unless one does not exist.)
+
+
+  - type: markdown
+    attributes:
+      value: |
+        Required ClusterRepo template:
+        ````yaml
+        ```yaml
+        apiVersion: catalog.cattle.io/v1
+        kind: ClusterRepo
+        metadata:
+          name: ob-team-charts-<your-name>
+        spec:
+          gitBranch: <your-feature-branch>
+          gitRepo: https://github.com/<your-github-username>/ob-team-charts
+        ```
+        ````
+  - type: textarea
+    id: clusterrepo_config
+    attributes:
+      label: ClusterRepo Config for QA
+      description: Provide the QA team a customized ClusterRepo YAML to install and test this chart
+      placeholder: |
+        ```yaml
+        apiVersion: catalog.cattle.io/v1
+        kind: ClusterRepo
+        metadata:
+          name: ob-team-charts-joe
+        spec:
+          gitBranch: joes-monitoring-bug-fix
+          gitRepo: https://github.com/joe/ob-team-charts
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Testing Considerations
+      description: Optional context for QA — what to test, what's changed, anything worth highlighting
+      placeholder: |
+        - This PR addresses issue #1234
+        - Focus on curl upgrade and verify alertmanager dashboards
+        - Can test using values from prior test case
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: true
+contact_links: []


### PR DESCRIPTION
Per title, this adds 2 issue templates to this repo; one for creating basic chart related issues. And a second for creating QA requests for chart testing.