### PR TITLE
[rancher-monitoring 69.8-rancher.x] Don't install Fleet ServiceMonitor unless namespace exists

### DIFF
--- a/packages/rancher-monitoring/69.8/rancher-monitoring/generated-changes/overlay/templates/rancher-monitoring/exporters/fleet/servicemonitor.yaml
+++ b/packages/rancher-monitoring/69.8/rancher-monitoring/generated-changes/overlay/templates/rancher-monitoring/exporters/fleet/servicemonitor.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.rancherMonitoring.enabled }}
+{{- $fleetNamespace := lookup "v1" "Namespace" "" "cattle-fleet-system" -}}
+{{- if and .Values.rancherMonitoring.enabled (gt (len $fleetNamespace) 0) -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -25,7 +26,7 @@ spec:
       app: fleet-controller
 {{- end }}
 ---
-{{- if .Values.rancherMonitoring.enabled }}
+{{- if and .Values.rancherMonitoring.enabled (gt (len $fleetNamespace) 0) -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
Which prevents the `rancher-monitoring` chart from failing when being installed on downstream clusters.

Fixes #51331