### PR TITLE
fix(build): Ensure bin directory exists

### DIFF
--- a/scripts/pull-scripts
+++ b/scripts/pull-scripts
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -e # Exit immediately if a command exits with a non-zero status.
 
-chmod -R a+x bin/ || true
-
 cd $(dirname $0) # Move to the directory of the script
 source ./version # Source the version file to set environment variables
 
@@ -39,6 +37,9 @@ echo "Downloading charts-build-scripts version ${CHARTS_BUILD_SCRIPTS_REPO}@${CH
 echo "remove existing ../bin/charts-build-scripts"
 rm -f ../bin/charts-build-scripts
 cd ..
+echo "Validating/Securing bin directory"
+mkdir -p bin # Ensure existence (creates if missing)
+chmod -R a+x bin/ # Ensure it's executable
 
 # Extract the OS and architecture from the go version command output
 OS=$(go version | cut -d' ' -f4 | cut -d'/' -f1)


### PR DESCRIPTION
### Issue


The pull-scripts execution failed during its first run with the error` chmod: bin/: No such file or directory` and `make: *** [pull-scripts] Error 56`
```
$ export PACKAGE="rancher-logging/4.10"
$make prepare
#!/bin/bash

./scripts/pull-scripts
chmod: bin/: No such file or directory
Check if charts-build-scripts binary is present on the target version
Expected the latest version!
Resolved latest version to v1.8.5
Downloading charts-build-scripts version https://github.com/rancher/charts-build-scripts.git@v1.8.5
remove existing ../bin/charts-build-scripts
OS: darwin
ARCH: arm64
BINARY_NAME: charts-build-scripts_darwin_arm64
Downloading https://github.com/rancher/charts-build-scripts/releases/download/v1.8.5/charts-build-scripts_darwin_arm64
make: *** [pull-scripts] Error 56
```

### Fix
The fix addresses the first-run failure `(chmod: bin/: No such file or directory)` by explicitly ensuring the bin directory exists and has the correct permissions.
