### PR TITLE
ci: Adopt new Rancher CI images for charts building

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,6 +36,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }} # Use the head SHA of the PR for checkout
           fetch-depth: 0
 
+      - name: Mark git directory as safe
+        shell: bash
+        run: git config --global --add safe.directory "$(pwd)"
+
       - name: Re-attach to Branch
         run: |
           git switch -c "${{ github.head_ref }}"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,25 +26,24 @@ jobs:
   verify-branch:
     name: Verify Branch State
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/rancher/ci-image/charts
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha }} # Use the head SHA of the PR for checkout
           fetch-depth: 0
 
-      - run: |
+      - name: Re-attach to Branch
+        run: |
           git switch -c "${{ github.head_ref }}"
-
-      - uses: rancherlabs/dep-fetch/actions/sync-deps@v0.1.1
-        with:
-          version: v0.1.1
 
       - name: Run branch verification
         run: |
           echo "Running branch verification on PR branch: ${{ github.head_ref }}"
-          ./bin/ob-charts-tool branchVerifyCheck
+          ob-charts-tool branchVerifyCheck
 
       # The verification will automatically:
       # - Exit with code 0 if all critical checks pass (warnings are OK)

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -30,7 +30,8 @@ jobs:
           fetch-depth: 0
 
       - name: Mark git directory as safe
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        shell: bash
+        run: git config --global --add safe.directory "$(pwd)"
 
       - uses: rancherlabs/dep-fetch/actions/sync-deps@v0.1.1
         with:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -16,7 +16,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: registry.suse.com/bci/bci-base:latest
+      image: ghcr.io/rancher/ci-image/charts
     permissions:
       contents: read
       id-token: write

--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,5 @@ Dockerfile.dapper*
 debug.yaml
 .charts-build-scripts/.cache
 .charts-build-scripts/.cache/**
-rebase.yaml
+rebase*.yaml
 .dep-fetch


### PR DESCRIPTION
This mainly covers concerns related to how CI works with things.

I think we will still leave `dep-fetch` as our local dev based helper tool. As that use case still requires the same tools. Eventually we can rewrite local tooling to also invoke tools via the images though - I think that is best long term.