### PR TITLE
fix: quote gitBranch in ClusterRepo

### DIFF
--- a/.github/workflows/test-monitoring.yml
+++ b/.github/workflows/test-monitoring.yml
@@ -206,7 +206,7 @@ jobs:
           metadata:
             name: ${REPO_NAME}
           spec:
-            gitBranch: ${BRANCH}
+            gitBranch: "${BRANCH}"
             gitRepo: https://github.com/${FORK_REPO}
           EOF
 


### PR DESCRIPTION
Ref: #262 

Quote `gitBranch` in `ClusterRepo` to prevent failing on branches that consist of only numbers.